### PR TITLE
More fixes to Game Status command

### DIFF
--- a/src/commands/gameStatus.ts
+++ b/src/commands/gameStatus.ts
@@ -63,7 +63,8 @@ export class GameStatus extends Command {
                 let labelNames = "";
                 for (const i of finalSearch.data.items[0].labels)
                     labelNames += `\`${i.name}\` `;
-                
+                if (labelNames = "")
+                    labelNames = "none";
                 let body = finalSearch.data.items[0].body!.split("###");
                 body.splice(0, 2);
                 body.splice(5, 1);


### PR DESCRIPTION
This commit allows the game status command to report a game even if no labels are found (thanks to Silverdragon_12 and Kimchi for spotting the issue with the bot)